### PR TITLE
Crear función para comparar resultados de comentarios

### DIFF
--- a/src/controllers/instagram.controller.ts
+++ b/src/controllers/instagram.controller.ts
@@ -1,5 +1,6 @@
 import { createProfileHistory } from '@/services/profile.service'
 import { scrapPostComments } from '@/services/post.service'
+import { syncPostCommentCounts } from '@/services/comment.service'
 import type { Response, Request } from 'express'
 
 /**
@@ -30,6 +31,27 @@ export const createProfileHistoryController = async (
 export const createPostCommentsController = async (req: Request, res: Response): Promise<void> => {
   try {
     const data = await scrapPostComments()
+    res.status(200).json(data)
+  } catch (error: unknown) {
+    console.error(error)
+    res.status(500).json({ message: (error as Error).message })
+  }
+}
+
+/**
+ * Sincroniza el valor `numberOfComments` de cada post con la cantidad real de
+ * comentarios almacenados en `comment_entity` y retorna un resumen de la
+ * operación.
+ * @param {Request} req - Objeto de la petición
+ * @param {Response} res - Objeto de la respuesta
+ * @returns {Promise<void>} Resumen de la sincronización
+ */
+export const syncPostCommentsController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const data = await syncPostCommentCounts()
     res.status(200).json(data)
   } catch (error: unknown) {
     console.error(error)

--- a/src/routes/instagram.ts
+++ b/src/routes/instagram.ts
@@ -2,11 +2,13 @@ import { Router } from 'express'
 import {
   createPostCommentsController,
   createProfileHistoryController,
+  syncPostCommentsController,
 } from '@/controllers/instagram.controller'
 
 const router = Router()
 
 router.get('/profile', createProfileHistoryController)
 router.get('/post', createPostCommentsController)
+router.get('/comments/sync', syncPostCommentsController)
 
 export default router

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -1,0 +1,68 @@
+import { prisma } from '@/config'
+
+/**
+ * Sincroniza la cantidad de comentarios de cada post con la cantidad real de
+ * comentarios almacenados en la tabla `comment_entity`.  De esta forma los
+ * resultados de las consultas que utilizan `instagram_post.numberOfComments`
+ * y las que contabilizan registros en `comment_entity` devolverán el mismo
+ * valor.
+ *
+ * Además devuelve un resumen con los posts que fueron actualizados para poder
+ * realizar verificaciones o auditorías posteriores.
+ *
+ * @returns {Promise<{ postsUpdated: number; details: { postId: number; titulo: string; cantOriginal: number; cantReal: number }[]; status: string }>}
+ * @throws {Error} Si no se encuentran posts almacenados en la base de datos.
+ */
+export const syncPostCommentCounts = async (): Promise<{
+  postsUpdated: number
+  details: { postId: number; titulo: string; cantOriginal: number; cantReal: number; cantAnalysis: number }[]
+  status: string
+}> => {
+  // Obtiene todos los posts con sus comentarios asociados
+  const posts = await prisma.instagram_post.findMany({
+    include: {
+      comment_entity: true,
+      comment_analysis: true,
+    },
+  })
+
+  if (posts.length === 0) throw new Error('No se encontraron posts en la base de datos')
+
+  let postsUpdated = 0
+  const details: { postId: number; titulo: string; cantOriginal: number; cantReal: number; cantAnalysis: number }[] = []
+
+  // Recorre los posts y compara el valor almacenado con la cantidad real
+  for (const post of posts) {
+    const realCount = post.comment_entity.length
+    const analysisCount = post.comment_analysis.length
+    const originalCount = post.numberOfComments ?? 0
+
+    const needsUpdate = realCount !== originalCount
+    const hasMismatch = needsUpdate || realCount !== analysisCount
+
+    if (needsUpdate) {
+      // Actualiza el valor de numberOfComments con la cantidad real
+      await prisma.instagram_post.update({
+        where: { id: post.id },
+        data: { numberOfComments: realCount },
+      })
+      postsUpdated++
+    }
+
+    if (hasMismatch) {
+      details.push({
+        postId: post.id,
+        titulo: post.title,
+        cantOriginal: originalCount,
+        cantReal: realCount,
+        cantAnalysis: analysisCount,
+      })
+    }
+  }
+
+  return {
+    postsUpdated,
+    details,
+    status: 'success',
+  }
+}


### PR DESCRIPTION
A new file `src/services/comment.service.ts` was created, introducing the `syncPostCommentCounts` function.

This function:
*   Retrieves all posts, including associated `comment_entity` and `comment_analysis` records.
*   Compares each post's `numberOfComments` with the actual count of `comment_entity` entries.
*   Updates `instagram_post.numberOfComments` if a discrepancy is found, ensuring consistency between different comment counting methods.
*   Returns a summary of updated posts and all discrepancies found.

To expose this functionality, a new controller `syncPostCommentsController` was added to `src/controllers/instagram.controller.ts`.
A GET route `/instagram/comments/sync` was registered in `src/routes/instagram.ts`, allowing the synchronization process to be triggered via an API endpoint.
This ensures that queries based on `instagram_post.numberOfComments` and `comment_entity` counts yield identical results.